### PR TITLE
Crash & filewatch fixes

### DIFF
--- a/src/fileWatch.js
+++ b/src/fileWatch.js
@@ -11,13 +11,12 @@ function fileFilter(file) {
     return false;
 }
 
-const watch = new CheapWatch({
-    dir: config.get("scriptsFolder"),
-    filter: fileFilter,
-    watch: !config.get("dry")
-});
-
 export async function setupWatch(signaller) {
+    const watch = new CheapWatch({
+        dir: config.get("scriptsFolder"),
+        filter: fileFilter,
+        watch: !config.get("dry")
+    });
 
     if (!config.get("quiet")) console.log("Watching folder", resolve(config.get("scriptsFolder")))
 
@@ -33,8 +32,4 @@ export async function setupWatch(signaller) {
     }
 
     return watch;
-}
-
-export function watchedFiles() {
-    return watch.paths;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ export async function start() {
     const socket = setupSocket(signal);
 
     // Add a handler for received messages.
-    signal.on(EventType.MessageReceived, msg => messageHandler(signal, msg));
+    signal.on(EventType.MessageReceived, msg => messageHandler(signal, msg, watch.paths));
 
     // Add a handler for when a connection to a game is made.
     signal.on(EventType.ConnectionMade, () => {

--- a/src/networking/messageHandler.js
+++ b/src/networking/messageHandler.js
@@ -1,11 +1,10 @@
 import { messageTracker } from "./messageTracker.js";
 import { writeFile } from "fs";
 import { config } from "../config.js";
-import { watchedFiles } from "../fileWatch.js";
 import { EventType } from "../eventTypes.js";
 import { fileChangeEventToMsg } from "./messageGenerators.js";
 
-export function messageHandler(signaller, msg) {
+export function messageHandler(signaller, msg, paths) {
     let incoming;
 
     try { incoming = JSON.parse(msg.toString()); }
@@ -15,7 +14,7 @@ export function messageHandler(signaller, msg) {
 
     if (incoming.result) {
         const request = messageTracker.get(incoming.id);
-        if (request.method &&
+        if (request?.method &&
             request.method == "getDefinitionFile"
             && incoming.result) {
             writeFile(config.get("definitionFile").location, incoming.result, (err) => {
@@ -23,12 +22,12 @@ export function messageHandler(signaller, msg) {
             });
         }
 
-        if (request.method &&
+        if (request?.method &&
             request.method == "getFileNames"
             && incoming.result) {
             const gameFiles = incoming.result.map(file => removeLeadingSlash(file));
 
-            watchedFiles().forEach((stats, fileName) => {
+            paths.forEach((stats, fileName) => {
                 if (!stats.isDirectory() && !gameFiles.includes(fileName))
                     signaller.emit(EventType.MessageSend, fileChangeEventToMsg({ path: fileName }));
             })

--- a/src/networking/messageTracker.js
+++ b/src/networking/messageTracker.js
@@ -6,7 +6,7 @@ class MessageTracker {
         this.data.set(msg.id, msg);
 
         if (this.data.size > this.#maxLength) {
-            const [firstKey] = map.keys();
+            const [firstKey] = this.data.keys();
             this.data.delete(firstKey);
         }
     }


### PR DESCRIPTION
`request` would sometimes be undefined, meaning `request.method` would crash.

`map` crashed as undefined, changed to `this.data`.

`watch` in the global scope of `fileWatch.js` was causing it to get initialized before `loadConfig()` was called in `index.js`, meaning it would have all the default values. Most pertinent was `watch.dir` being initialized to `.`, which meant the file watcher would include every file in the template project, including node_modules. Pulling it to the function scope meant `watchedFiles()` couldn't see the reference, so I just passed `watch.paths` to `messageHandler` directly from `index.js`.