### PR TITLE
update repo URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Hoekstraa/bitburner-remote.git"
+    "url": "git+https://github.com/bitburner-official/bitburner-filesync.git"
   },
   "keywords": [
     "bitburner",


### PR DESCRIPTION
Hunting down why I can't get `npx bitburner-filesync` to work from npm script, but works on the command line and I noticed this.  It isn't going to fix me, but this should probably match the true repo location 😎