### PR TITLE
Fix `deleteFile` events

### DIFF
--- a/src/networking/messageGenerators.js
+++ b/src/networking/messageGenerators.js
@@ -22,6 +22,7 @@ export function fileRemovalEventToMsg({ path }) {
         "jsonrpc": "2.0",
         "method": "deleteFile",
         "params": {
+            "server": "home",
             "filename": path,
         },
         "id": messageCounter++


### PR DESCRIPTION
Previously when deleting a file, I received:
```
{ jsonrpc: '2.0', error: 'Message misses parameters', id: 1 }
```

This was due to the missing `server` parameter that is required when sending a `deleteFile` event. This PR just adds in the missing parameter. After adding this in, deletions are sent without error:

![Code_oM7kTIst7l](https://user-images.githubusercontent.com/1153142/192882586-00c0eac7-7038-4eb3-a62c-b0fc93f105bb.png)
