### PR TITLE
Log download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
+NetScriptDefinitions.d.ts
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json

--- a/filesync.json
+++ b/filesync.json
@@ -1,0 +1,21 @@
+{
+    "allowedFiletypes": [
+      ".js"      
+    ],
+    "allowDeletingFiles": true,
+    "port": 12525,
+    "scriptsFolder": "c:\\git\\bitburner\\out",
+    "quiet": false,
+    "dry": false,
+    "definitionFile": {
+      "update": true,
+      "location": "NetScriptDefinitions.d.ts"
+    },
+    "logFiles": { 
+        "update": true,
+        "interval": 1,
+        "remoteLocation": "/logs/",
+        "localLocation": "D:\\bitburner_game_logs"
+    },    
+    "pushAllOnConnection": true
+  }

--- a/filesync.json
+++ b/filesync.json
@@ -13,7 +13,7 @@
     },
     "logFiles": { 
         "update": true,
-        "interval": 1,
+        "interval": 30,
         "remoteLocation": "/logs/",
         "localLocation": "D:\\bitburner_game_logs"
     },    

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,6 +42,32 @@ export const config = convict({
     default: false,
     arg: "dry",
   },
+  logFiles: { 
+    update: { 
+      doc: "Automatically pull the log files from the game.",
+      format: "Boolean",
+      env: "BB_UPDATE_LOG",
+      default: false
+    },
+    interval: {
+      doc: "Interval in seconds to pull log files from the game.",
+      format: "Number",
+      env: "BB_UPDATE_LOG_INTERVAL",
+      default: 5
+    },
+    remoteLocation: {
+      doc: "Folder where log files are stored in the game.",
+      format: "String",
+      env: "BB_LOCATION_LOG",
+      default: "/logs"
+    },
+    localLocation: {
+      doc: "Folder where log files are stored locally.",
+      format: "String",
+      env: "BB_LOCATION_LOG_LOCAL",
+      default: "./logs"
+    }    
+  },
   definitionFile: {
     update: {
       doc: "Automatically pull the definition file from the game.",

--- a/src/fileWatch.ts
+++ b/src/fileWatch.ts
@@ -3,6 +3,7 @@ import { config } from "./config";
 import { EventType } from "./eventTypes";
 import { mkdir } from "fs/promises";
 import { resolve } from "path";
+import { getAllFiles } from "./networking/messageGenerators";
 import type { Signal } from "signal-js";
 import type { File } from "./interfaces";
 
@@ -19,6 +20,17 @@ export async function setupLogsFolder() {
     if (isError(err) && err.code !== "EEXIST") {
       console.log(`Failed to create folder '${config.get("logFiles").localLocation}' (${err.code})`);
       process.exit();
+    }
+  }
+}
+
+export async function monitorLogs(signaller: Signal)
+{  
+  if (config.get("logFiles").update) {
+    await setupLogsFolder();
+    while(true) {
+      signaller.emit(EventType.MessageSend, getAllFiles());              
+      await new Promise((resolve) => setTimeout(resolve, config.get("logFiles").interval * 1000));
     }
   }
 }

--- a/src/fileWatch.ts
+++ b/src/fileWatch.ts
@@ -12,6 +12,17 @@ function fileFilter(file: File) {
   return false;
 }
 
+export async function setupLogsFolder() {
+  try {
+    await mkdir(resolve(config.get("logFiles").localLocation));
+  } catch (err) {
+    if (isError(err) && err.code !== "EEXIST") {
+      console.log(`Failed to create folder '${config.get("logFiles").localLocation}' (${err.code})`);
+      process.exit();
+    }
+  }
+}
+
 function isError(err: unknown): err is NodeJS.ErrnoException {
   return (err as NodeJS.ErrnoException).code !== undefined;
 }

--- a/src/networking/messageGenerators.ts
+++ b/src/networking/messageGenerators.ts
@@ -49,6 +49,17 @@ export function requestFilenames(): Message {
   };
 }
 
+export function getAllFiles(): Message {
+  return {
+    jsonrpc: "2.0",
+    method: "getAllFiles",
+    params: {
+      server: "home",
+    },
+    id: messageCounter++,
+  };
+}
+
 function addLeadingSlash(path: string): string {
   const slashes = path.match("/");
   if (slashes) return `/${path}`;

--- a/src/networking/messageHandler.ts
+++ b/src/networking/messageHandler.ts
@@ -32,13 +32,14 @@ export function isStringArray(s: Array<unknown>): s is string[] {
   return s.every((s) => typeof s === "string");
 }
 
-export function messageHandler(signaller: Signal, 
-  data: RawData, 
-  paths: Map<string, Stats>, 
-  updateLogs: boolean,
-  remoteLogFolder: string, 
-  localLogFolder: string) {
+export function messageHandler(signaller: Signal, data: RawData, paths: Map<string, Stats>) {
+
+  let updateLogs: boolean = config.get("logFiles").update;
+  let remoteLogFolder: string = config.get("logFiles").remoteLocation;
+  let localLogFolder: string = config.get("logFiles").localLocation;
+
   let incoming;
+
 
   try {
     incoming = deserialize(data);
@@ -85,7 +86,7 @@ export function messageHandler(signaller: Signal,
           }
         }
       }
-          
+
     break;
   }
 }


### PR DESCRIPTION
I wanted to be able to use Grafana to search logs and capture information about the performance of my scripts, in particular the stock market scripts. Originally I would log to a file in game, then save the file and extract the contents. To simply things, I updated the bitburner-filesync to be able to download all the files in a configured directory within the game to the local filesystem.

This allows me to log to a file within a /logs folder in the game, then sync them to my local filesystem and from there use the Grafana agent to automatically push the logs to Grafana.

Providing my changes to the filesync in case others may want to be able to get logs extracted from the game as well.