### PR TITLE
Support specifying host to bind to in config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,13 @@ export const config = convict({
     default: false,
     arg: "allowDeletingFiles",
   },
+  host: {
+    doc: "The host to bind to.",
+    format: "String",
+    nullable: true,
+    default: null,
+    arg: "host",
+  },
   port: {
     doc: "The port to bind to.",
     format: "Number",

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,8 @@ export async function start() {
       signal.emit(EventType.MessageSend, fileRemovalEventToMsg(fileEvent)),
     );
 
-  console.log(`Server is ready, running on ${config.get("port")}!`);
+  const configHost = config.get("host");
+  console.log(`Server is ready, running on ${configHost != null ? configHost + ":" : ""}${config.get("port")}!`);
 
   process.on("SIGINT", function () {
     console.log("Shutting down!");

--- a/src/networking/webSocket.ts
+++ b/src/networking/webSocket.ts
@@ -6,7 +6,8 @@ import { Message } from "../interfaces.js";
 import { messageTracker } from "./messageTracker.js";
 
 export function setupSocket(signaller: Signal) {
-  const wss = new WebSocketServer({ port: config.get("port") });
+  const configHost: string | null = config.get("host");
+  const wss = new WebSocketServer({ port: config.get("port"), host: configHost ?? undefined });
 
   wss.on("connection", function connection(ws) {
     function sendMessage(msg: Message) {


### PR DESCRIPTION
This should allow running listening only on localhost for better security when bitburner and the sync are both run on the same host, which I imagine is common.

Ran tests for commit:
npm run format
npm run lint
npm run test

(all tests passed)

Ran the program with unchanged config (no host specified), observed still listening on [::], observed able to connect and sync from bitburner on another host.

Added the host option set to localhost, ran again and observed I was unable to connect from the other host.

AI use: I asked AI for advice to save figuring out some project details myself, but all of the code changes were written myself.