### PR TITLE
Add "ambient" definition file option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Here's an example of it's contents:
   "definitionFile": {
     "update": false,
     "location": "NetScriptDefinitions.d.ts",
-    "ambient": true
+    "removeExportFromDeclarations": false
   },
   "pushAllOnConnection": false
 }

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Here's an example of it's contents:
     "update": false,
     "location": "NetScriptDefinitions.d.ts"
   },
-  "pushAllOnConnection": false
+  "pushAllOnConnection": false,
+  "ambient": true
 }
 ```

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Here's an example of it's contents:
   "dry": false,
   "definitionFile": {
     "update": false,
-    "location": "NetScriptDefinitions.d.ts"
+    "location": "NetScriptDefinitions.d.ts",
+    "ambient": true
   },
-  "pushAllOnConnection": false,
-  "ambient": true
+  "pushAllOnConnection": false
 }
 ```

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,6 +60,12 @@ export const config = convict({
       env: "BB_LOCATION_DEF",
       default: "./NetScriptDefinitions.d.ts",
     },
+    ambient: {
+      doc: "Modify the definition file like the in-game editor does.",
+      format: "Boolean",
+      env: "BB_AMBIENT_DEF",
+      default: false,
+    },
   },
   pushAllOnConnection: {
     doc: "Push all files when initial connection is made.",

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,8 +60,8 @@ export const config = convict({
       env: "BB_LOCATION_DEF",
       default: "./NetScriptDefinitions.d.ts",
     },
-    ambient: {
-      doc: "Modify the definition file like the in-game editor does.",
+    removeExportFromDeclarations: {
+      doc: "Remove `export` from definition file declarations to use Netscript types and functions without an `import`, like the in-game editor.",
       format: "Boolean",
       env: "BB_AMBIENT_DEF",
       default: false,

--- a/src/networking/messageHandler.ts
+++ b/src/networking/messageHandler.ts
@@ -48,7 +48,7 @@ export function messageHandler(signaller: Signal, data: RawData, paths: Map<stri
 
       let result = incoming.result;
       if (config.get("definitionFile").ambient) {
-        result = result.replace(/export /g, "");
+        result = result.replace(/^export /gm, "");
       }
 
       writeFile(config.get("definitionFile").location, result, (err) => {

--- a/src/networking/messageHandler.ts
+++ b/src/networking/messageHandler.ts
@@ -43,14 +43,20 @@ export function messageHandler(signaller: Signal, data: RawData, paths: Map<stri
   }
 
   switch (incoming.method) {
-    case "getDefinitionFile":
+    case "getDefinitionFile": {
       if (typeof incoming.result !== "string") return console.log("Malformed data received.");
 
-      writeFile(config.get("definitionFile").location, incoming.result, (err) => {
+      let result = incoming.result;
+      if (config.get("definitionFile").ambient) {
+        result = result.replace(/export /g, "");
+      }
+
+      writeFile(config.get("definitionFile").location, result, (err) => {
         if (err) return console.log(err);
       });
 
       break;
+    }
     case "getFileNames": {
       if (!Array.isArray(incoming.result) || !isStringArray(incoming.result))
         return console.log("Malformed data received.");

--- a/src/networking/messageHandler.ts
+++ b/src/networking/messageHandler.ts
@@ -47,7 +47,7 @@ export function messageHandler(signaller: Signal, data: RawData, paths: Map<stri
       if (typeof incoming.result !== "string") return console.log("Malformed data received.");
 
       let result = incoming.result;
-      if (config.get("definitionFile").ambient) {
+      if (config.get("definitionFile").removeExportFromDeclarations) {
         result = result.replace(/^export /gm, "");
       }
 


### PR DESCRIPTION
Bitburner's Script Editor (using Monaco) provides types from the definition file ambiently. To do so, Bitburner modifies the definition file in this same way before providing it to Monaco (https://github.com/bitburner-official/bitburner-src/blob/2e83ba9ce9b688540d9f60cf4b0245fd53bea9e0/src/ScriptEditor/ui/Editor.tsx#L48). Now that Bitburner can execute TS natively, I would like the same experience outside of Bitburner when developing scripts. I currently need to strip `import` lines that refer to the unmodified definition file, or else sync the definition file back into Bitburner so scripts can refer to the modified definition file.

I think this should actually be the responsibility of Bitburner rather than RFA implementors, but the Bitburner team has already specified they won't fix this and consider it the responsibility of each RFA implementation (https://github.com/bitburner-official/bitburner-src/issues/2471).